### PR TITLE
feat: convert team page to flat yaml files

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -1,6 +1,5 @@
 import { defineCollection, defineContentConfig, z } from "@nuxt/content";
 
-
 export default defineContentConfig({
   collections: {
     policies: defineCollection({
@@ -27,6 +26,22 @@ export default defineContentConfig({
           alt: z.string()
         }).optional(),
         lastUpdated: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid Date")
+      })
+    }),
+    team: defineCollection({
+      type: 'data',
+      source: 'team/**.yml',
+      schema: z.object({
+        year: z.number(),
+        elected: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid Date"),
+        committee: z.array(
+          z.object({
+            name: z.string(),
+            role: z.string(),
+            portrait: z.string().optional(),
+            resigned: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid Date").optional() // defaults to null
+          })
+        )
       })
     })
   }

--- a/content/team/2025.yml
+++ b/content/team/2025.yml
@@ -1,0 +1,13 @@
+# The Committee board, elected on the 6th Jan 2025.
+year: 2025
+elected: 2025-01-06
+committee:
+  - name: Duale Siad
+    role: President
+  - name: Arden Gough Phillips
+    role: Vice President & Acting Secretary
+  - name: Danielle Birkett
+    role: Treasurer
+  - name: Thomas Handbury
+    role: Secretary
+    resigned: 2025-09-10

--- a/pages/team.vue
+++ b/pages/team.vue
@@ -1,6 +1,11 @@
-<script setup>
+<script setup lang="ts">
 import Navbar from '~/components/nav/Navbar.vue';
 import Footer from '~/components/nav/Footer.vue';
+import { formatDate } from '~/lib/dateUtil';
+
+const {data: committee} = await useAsyncData("team", () => {
+  return queryCollection("team").order('id', 'DESC').all();
+});
 </script>
 
 <template>
@@ -12,19 +17,12 @@ import Footer from '~/components/nav/Footer.vue';
       <span class="text-xl font-light">Want to join the team? <NuxtLink class="underline" href="/contact">Contact us today</NuxtLink>!</span>
       <section class="flex flex-col gap-4 w-full">
         <h1 class="text-xl font-bold">Committee</h1>
-        <h2 class="text-lg font-regular italic">As appointed at 2025-01-06. Acting secretary appointed 2025-09-08.</h2>
-        <div class="flex flex-col lg:flex-row gap-8 justify-center">
-          <div class="flex flex-col rounded-md bg-bg text-fg p-4 gap-2">
-            <h1 class="text-xl font-bold">Duale Siad</h1>
-            <span class="text-lg font-semibold">President</span>
-          </div>
-          <div class="flex flex-col rounded-md bg-bg text-fg p-4 gap-2">
-            <h1 class="text-xl font-bold">Arden Gough Phillips</h1>
-            <span class="text-lg font-semibold">Acting Secretary</span>
-          </div>
-          <div class="flex flex-col rounded-md bg-bg text-fg p-4 gap-2">
-            <h1 class="text-xl font-bold">Danielle Birkett</h1>
-            <span class="text-lg font-semibold">Treasurer</span>
+        <span class="text-lg">As elected at {{ formatDate(committee[0].elected) }}.</span>
+        <div class="grid max-w-fit grid-cols-2 gap-4">
+          <div v-for="member in committee[0].committee" :key="member.name" class="flex flex-col max-h-fit bg-bg text-fg p-4 gap-2 rounded-lg self-center items-center">
+            <h1 class="text-lg font-bold">{{ member.name }}</h1>
+            <span class="text-sm">{{ member.role }}</span>
+            <span v-if="member.resigned" class="text-xs italic">Resigned on {{ formatDate(member.resigned) }}</span>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Converts the [/team](https://stra.org.au/team) page to a flat file, in order to future proof the website and not require a web developer to update this webpage.

See the [`content/team/2025.yaml`](https://github.com/straorgau/website/blob/555bf3ea79d9e9279b2bd33bec4d4402fb755e3c/content/team/2025.yml) file for an example of the format.

Closes #10 